### PR TITLE
Travis: drop unused sudo: false; use Rubinius 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 rvm:
   - 1.9.3
   - 2.0
@@ -10,9 +8,12 @@ rvm:
   - 2.3.0
   - 2.4.1
   - ruby-head
-  - rbx
 
 matrix:
+  include:
+    - rvm: rbx-4
+      dist: trusty
+      name: Rubinius
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx
+    - name: Rubinius


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

Also: pick trusty for Rubinius, and choose latest Rubinius