### PR TITLE
Fix incompatible function pointer types

### DIFF
--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -3768,7 +3768,7 @@ rb_thread_unsafe_dangerous_crazy_blocking_region_end(...);
 #if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
         poll_args.loop = loop;
         poll_args.waittime = waittime;
-        rb_thread_call_without_gvl(ev_backend_poll, (void *)&poll_args, RUBY_UBF_IO, 0);
+        rb_thread_call_without_gvl((void *)ev_backend_poll, (void *)&poll_args, RUBY_UBF_IO, 0);
 #else
          backend_poll (EV_A_ waittime);
 #endif


### PR DESCRIPTION
Clang 16 enables -Werror=incompatible-function-pointer-types, (-Werror=incompatible-pointer-type for GCC). This leads to erros such as:

```
In file included from libev.c:8:
./../libev/ev.c:3771:36: error: incompatible function pointer types passing
      'VALUE (void *)' (aka 'unsigned long (void *)') to parameter of type
      'void *(*)(void *)' [-Werror,-Wincompatible-function-pointer-types]
        rb_thread_call_without_gvl(ev_backend_poll, (void *)&poll_args, ...
                                   ^~~~~~~~~~~~~~~
```

This commit should fix this build error.

Bug: https://bugs.gentoo.org/883147