### PR TITLE
Support Ruby 3.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
-          # - "head"
+          - "head"
         
         experimental: [false]
         

--- a/ext/cool.io/extconf.rb
+++ b/ext/cool.io/extconf.rb
@@ -4,6 +4,7 @@ libs = []
 
 $defs << "-DRUBY_VERSION_CODE=#{RUBY_VERSION.gsub(/\D/, '')}"
 
+have_func('rb_io_descriptor')
 have_func('rb_thread_blocking_region')
 have_func('rb_thread_call_without_gvl')
 have_func('rb_thread_alone')

--- a/ext/cool.io/iowatcher.c
+++ b/ext/cool.io/iowatcher.c
@@ -65,11 +65,6 @@ static VALUE Coolio_IOWatcher_initialize(int argc, VALUE *argv, VALUE self)
   char *flags_str;
   int events;
   struct Coolio_Watcher *watcher_data;
-#if defined(HAVE_RB_IO_T) || defined(HAVE_RB_IO_DESCRIPTOR)
-  rb_io_t *fptr;
-#else
-  OpenFile *fptr;
-#endif
 
   rb_scan_args(argc, argv, "11", &io, &flags);
 
@@ -89,12 +84,17 @@ static VALUE Coolio_IOWatcher_initialize(int argc, VALUE *argv, VALUE self)
 
   Data_Get_Struct(self, struct Coolio_Watcher, watcher_data);
   io = rb_convert_type(io, T_FILE, "IO", "to_io");
-  GetOpenFile(io, fptr);
 
   watcher_data->dispatch_callback = Coolio_IOWatcher_dispatch_callback;
 #ifdef HAVE_RB_IO_DESCRIPTOR
   ev_io_init(&watcher_data->event_types.ev_io, Coolio_IOWatcher_libev_callback, rb_io_descriptor(io), events);
 #else
+#if defined(HAVE_RB_IO_T)
+  rb_io_t *fptr;
+#else
+  OpenFile *fptr;
+#endif
+  GetOpenFile(io, fptr);
   ev_io_init(&watcher_data->event_types.ev_io, Coolio_IOWatcher_libev_callback, FPTR_TO_FD(fptr), events);
 #endif
   watcher_data->event_types.ev_io.data = (void *)self;

--- a/ext/cool.io/iowatcher.c
+++ b/ext/cool.io/iowatcher.c
@@ -5,7 +5,7 @@
  */
 
 #include "ruby.h"
-#if defined(HAVE_RUBY_IO_H) || defined(HAVE_RB_IO_DESCRIPTOR)
+#if defined(HAVE_RUBY_IO_H)
 #include "ruby/io.h"
 #else
 #include "rubyio.h"

--- a/ext/iobuffer/extconf.rb
+++ b/ext/iobuffer/extconf.rb
@@ -1,6 +1,7 @@
 require 'mkmf'
 
 dir_config("iobuffer")
+have_func("rb_io_descriptor")
 have_library("c", "main")
 if have_macro("HAVE_RB_IO_T", "ruby/io.h")
   have_struct_member("rb_io_t", "fd", "ruby/io.h")

--- a/ext/iobuffer/iobuffer.c
+++ b/ext/iobuffer/iobuffer.c
@@ -378,17 +378,22 @@ IO_Buffer_read_from(VALUE self, VALUE io)
 {
     struct buffer  *buf;
     int             ret;
-#if HAVE_RB_IO_T
+#if defined(HAVE_RB_IO_T) || defined(HAVE_RB_IO_DESCRIPTOR)
     rb_io_t        *fptr;
 #else
     OpenFile       *fptr;
 #endif
 
     Data_Get_Struct(self, struct buffer, buf);
-    GetOpenFile(rb_convert_type(io, T_FILE, "IO", "to_io"), fptr);
+    io = rb_convert_type(io, T_FILE, "IO", "to_io");
+    GetOpenFile(io, fptr);
     rb_io_set_nonblock(fptr);
 
+#ifdef HAVE_RB_IO_DESCRIPTOR
+    ret = rb_io_descriptor(io);
+#else
     ret = buffer_read_from(buf, FPTR_TO_FD(fptr));
+#endif
     return ret == -1 ? Qnil : INT2NUM(ret);
 }
 
@@ -404,17 +409,22 @@ static VALUE
 IO_Buffer_write_to(VALUE self, VALUE io)
 {
     struct buffer  *buf;
-#if HAVE_RB_IO_T
+#if defined(HAVE_RB_IO_T) || defined(HAVE_RB_IO_DESCRIPTOR)
     rb_io_t        *fptr;
 #else
     OpenFile       *fptr;
 #endif
 
     Data_Get_Struct(self, struct buffer, buf);
-    GetOpenFile(rb_convert_type(io, T_FILE, "IO", "to_io"), fptr);
+    io = rb_convert_type(io, T_FILE, "IO", "to_io");
+    GetOpenFile(io, fptr);
     rb_io_set_nonblock(fptr);
 
+#ifdef HAVE_RB_IO_DESCRIPTOR
+    return INT2NUM(rb_io_descriptor(io));
+#else
     return INT2NUM(buffer_write_to(buf, FPTR_TO_FD(fptr)));
+#endif
 }
 
 /*

--- a/ext/iobuffer/iobuffer.c
+++ b/ext/iobuffer/iobuffer.c
@@ -390,7 +390,7 @@ IO_Buffer_read_from(VALUE self, VALUE io)
     rb_io_set_nonblock(fptr);
 
 #ifdef HAVE_RB_IO_DESCRIPTOR
-    ret = rb_io_descriptor(io);
+    ret = buffer_read_from(buf, rb_io_descriptor(io));
 #else
     ret = buffer_read_from(buf, FPTR_TO_FD(fptr));
 #endif
@@ -421,7 +421,7 @@ IO_Buffer_write_to(VALUE self, VALUE io)
     rb_io_set_nonblock(fptr);
 
 #ifdef HAVE_RB_IO_DESCRIPTOR
-    return INT2NUM(rb_io_descriptor(io));
+    return INT2NUM(buffer_write_to(buf, rb_io_descriptor(io)));
 #else
     return INT2NUM(buffer_write_to(buf, FPTR_TO_FD(fptr)));
 #endif


### PR DESCRIPTION
Fix #77

This follows the example fix shown in [[Feature #19057]](https://bugs.ruby-lang.org/issues/19057#note-18) at [94dbdd9497](https://github.com/casperisfine/raindrops/commit/94dbdd94977d895f98c084d0ca31c2b9cf0d25d3). I also changed `#if HAVE_RB_IO_T` to `#if defined(HAVE_RB_IO_T)` so that it will not print warnings when not defined.