### PR TITLE
Windows: Fix build error incompatible pointer types

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,12 @@ jobs:
     continue-on-error: ${{matrix.experimental}}
     
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu
           - macos
+          - windows
         
         ruby:
           - "3.0"

--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -2481,7 +2481,7 @@ evpipe_write (EV_P_ EV_ATOMIC_T *flag)
 #ifdef _WIN32
           WSABUF buf;
           DWORD sent;
-          buf.buf = &buf;
+          buf.buf = (char *)&buf;
           buf.len = 1;
           WSASend (EV_FD_TO_WIN32_HANDLE (evpipe [1]), &buf, 1, &sent, 0, 0, 0);
 #else


### PR DESCRIPTION
On GitHub workflows, building the native extensions for `cool.io` fails as follows:

    ../libev/ev.c: In function 'evpipe_write':
    ../libev/ev.c:2484:19: error: assignment to 'char *' from incompatible pointer
    type 'WSABUF *' [-Wincompatible-pointer-types]
     2484 |           buf.buf = &buf;
          |                   ^

* Runner: windows-2022 (20240421.1.0)
* Use `ruby/setup-ruby v1` to set up Ruby
  * https://github.com/actions/setup-ruby
* Dependency: `cool.io` v1.8.0

I have tested this by enabling Windows CI on my fork.
You can see this error occurs on Windows:

* https://github.com/daipom/cool.io/actions/runs/9060771058

In addition, I have made the test repository that depends on `cool.io`.
You can check this error here too:

* https://github.com/daipom/Test-Windows-CI-For-Ruby/actions/runs/9059543449

**About this fix**

The type of `buf` member of `WSABUF` is `char *`:

* https://learn.microsoft.com/en-us/windows/win32/api/ws2def/ns-ws2def-wsabuf

On `libev` upstream, this was already fixed on v4.25:

http://cvs.schmorp.de/libev/ev.c?r1=1.484&r2=1.485&pathrev=rel-4_25

Maybe we should try to update the overall `libev` version, but that could be difficult.
This PR intends to fix this error first.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
  - We can check this change by enabling Windows CI. So, I have included it in this PR.
  - Without this fix, the CI on Windows fails: https://github.com/daipom/cool.io/actions/runs/9060771058
  - With this fix, it succeeds: https://github.com/daipom/cool.io/actions/runs/9060821025
- [ ] I tested my changes locally.
  - I can't reproduce this error on my local, but we can confirm this fix resolves the build error in the CI.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
